### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/aliasfalse/warframe-forum-dark.png?label=ready&title=Ready)](https://waffle.io/aliasfalse/warframe-forum-dark)
 # warframe-forum-dark
 
 ## Installation


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/aliasfalse/warframe-forum-dark

This was requested by a real person (user aliasfalse) on waffle.io, we're not trying to spam you.
